### PR TITLE
Fix card transition animation bug

### DIFF
--- a/src/app/components/CardContainer.tsx
+++ b/src/app/components/CardContainer.tsx
@@ -83,7 +83,7 @@ export default function CardContainer({
   return (
     <div className="w-full h-full">
       <div className="flex flex-col gap-4 m-4">
-        <Card className={`p-4 gap-0`}>
+        <Card key={card.id} className={`p-4 gap-0`}>
           {card.front}
           <div
             className={`grid transition-all duration-200 ease-in-out ${

--- a/src/app/hooks/useCard.ts
+++ b/src/app/hooks/useCard.ts
@@ -24,15 +24,21 @@ export default function useCard(deckId: string): {
   const reviewCard = (card: CardType, rating: number) => {
     console.log(`Reviewed card ${card.id} with rating ${rating}`);
 
-    // Move to next card
-    if (currentCardIndex < cards.length - 1) {
-      setCurrentCardIndex(currentCardIndex + 1);
-    } else {
-      // End of deck - could reset or show completion message
-      console.log("End of deck reached");
-      setCurrentCardIndex(0);
-    }
+    // Hide the back content immediately
     setBackHidden(true);
+
+    // Delay the card change to allow the animation to complete
+    // The animation duration is 200ms, so we wait 250ms to be safe
+    setTimeout(() => {
+      // Move to next card
+      if (currentCardIndex < cards.length - 1) {
+        setCurrentCardIndex(currentCardIndex + 1);
+      } else {
+        // End of deck - could reset or show completion message
+        console.log("End of deck reached");
+        setCurrentCardIndex(0);
+      }
+    }, 250);
   };
 
   const currentCard = cards[currentCardIndex] || null;

--- a/src/app/hooks/useCard.ts
+++ b/src/app/hooks/useCard.ts
@@ -24,21 +24,16 @@ export default function useCard(deckId: string): {
   const reviewCard = (card: CardType, rating: number) => {
     console.log(`Reviewed card ${card.id} with rating ${rating}`);
 
-    // Hide the back content immediately
+    // Move to next card and ensure back is hidden
+    // Both state updates happen simultaneously to avoid animation issues
     setBackHidden(true);
-
-    // Delay the card change to allow the animation to complete
-    // The animation duration is 200ms, so we wait 250ms to be safe
-    setTimeout(() => {
-      // Move to next card
-      if (currentCardIndex < cards.length - 1) {
-        setCurrentCardIndex(currentCardIndex + 1);
-      } else {
-        // End of deck - could reset or show completion message
-        console.log("End of deck reached");
-        setCurrentCardIndex(0);
-      }
-    }, 250);
+    if (currentCardIndex < cards.length - 1) {
+      setCurrentCardIndex(currentCardIndex + 1);
+    } else {
+      // End of deck - could reset or show completion message
+      console.log("End of deck reached");
+      setCurrentCardIndex(0);
+    }
   };
 
   const currentCard = cards[currentCardIndex] || null;

--- a/src/app/hooks/useCard.ts
+++ b/src/app/hooks/useCard.ts
@@ -23,9 +23,6 @@ export default function useCard(deckId: string): {
 
   const reviewCard = (card: CardType, rating: number) => {
     console.log(`Reviewed card ${card.id} with rating ${rating}`);
-
-    // Move to next card and ensure back is hidden
-    // Both state updates happen simultaneously to avoid animation issues
     setBackHidden(true);
     if (currentCardIndex < cards.length - 1) {
       setCurrentCardIndex(currentCardIndex + 1);


### PR DESCRIPTION
Fixes the flashing of the next card's back content when transitioning by using React keys to force re-render.

Previously, the CSS transition for hiding the card's back was applied when switching to a new card, causing the new card's back to briefly flash before collapsing. By adding a `key` prop to the `Card` component, React now unmounts the old card and mounts the new one, ensuring the new card renders directly in its `backHidden` state without an unwanted transition. This also removes the need for fragile `setTimeout` based synchronization.