### PR TITLE
Enable markdown rendering for cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.3.1",
     "react-markdown": "^9.0.3",
-    "rehype-sanitize": "^5.0.1"
+    "rehype-sanitize": "^5.0.1",
+    "remark-gfm": "^3.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "openai": "^5.8.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "react-markdown": "^9.0.3",
+    "rehype-sanitize": "^5.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/components/CardContainer.tsx
+++ b/src/app/components/CardContainer.tsx
@@ -1,6 +1,8 @@
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { useEffect } from "react";
+import ReactMarkdown from "react-markdown";
+import rehypeSanitize from "rehype-sanitize";
 import { CardType } from "../hooks/useCard";
 
 export default function CardContainer({
@@ -84,7 +86,7 @@ export default function CardContainer({
     <div className="w-full h-full">
       <div className="flex flex-col gap-4 m-4">
         <Card key={card.id} className={`p-4 gap-0`}>
-          {card.front}
+          <ReactMarkdown rehypePlugins={[rehypeSanitize]}>{card.front}</ReactMarkdown>
           <div
             className={`grid transition-all duration-200 ease-in-out ${
               backHidden
@@ -94,7 +96,7 @@ export default function CardContainer({
           >
             <div className="overflow-hidden">
               <div className="w-full h-px bg-gray-300 my-4" />
-              {card.back}
+              <ReactMarkdown rehypePlugins={[rehypeSanitize]}>{card.back}</ReactMarkdown>
             </div>
           </div>
         </Card>

--- a/src/app/components/CardContainer.tsx
+++ b/src/app/components/CardContainer.tsx
@@ -3,6 +3,7 @@ import { Card } from "@/components/ui/card";
 import { useEffect } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeSanitize from "rehype-sanitize";
+import remarkGfm from "remark-gfm";
 import { CardType } from "../hooks/useCard";
 
 export default function CardContainer({
@@ -86,7 +87,12 @@ export default function CardContainer({
     <div className="w-full h-full">
       <div className="flex flex-col gap-4 m-4">
         <Card key={card.id} className={`p-4 gap-0`}>
-          <ReactMarkdown rehypePlugins={[rehypeSanitize]}>{card.front}</ReactMarkdown>
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            rehypePlugins={[rehypeSanitize]}
+          >
+            {card.front}
+          </ReactMarkdown>
           <div
             className={`grid transition-all duration-200 ease-in-out ${
               backHidden
@@ -96,7 +102,12 @@ export default function CardContainer({
           >
             <div className="overflow-hidden">
               <div className="w-full h-px bg-gray-300 my-4" />
-              <ReactMarkdown rehypePlugins={[rehypeSanitize]}>{card.back}</ReactMarkdown>
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeSanitize]}
+              >
+                {card.back}
+              </ReactMarkdown>
             </div>
           </div>
         </Card>

--- a/src/app/components/ChatInput.tsx
+++ b/src/app/components/ChatInput.tsx
@@ -34,14 +34,14 @@ export default function ChatInput({
     if (textareaRef.current && !isStreaming) {
       textareaRef.current.focus();
     }
-  }, [isStreaming]);
+  }, [isStreaming, textareaRef]);
 
   // Auto-focus on mount
   useEffect(() => {
     if (textareaRef.current) {
       textareaRef.current.focus();
     }
-  }, []);
+  }, [textareaRef]);
 
   // Reset selected index when commands change
   useEffect(() => {
@@ -82,7 +82,7 @@ export default function ChatInput({
         textareaRef.current.setSelectionRange(length, length);
       }
     },
-    [value, onChange]
+    [value, onChange, textareaRef]
   );
 
   const handleKeyDown = useCallback(


### PR DESCRIPTION
## Summary
- add markdown parsing dependencies and sanitize output
- render card content with ReactMarkdown
- fix lint warnings in `ChatInput`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686979a6b464832bbbd8d6a6599fadc7